### PR TITLE
Add OwnerReferences to KconfigBinding

### DIFF
--- a/controllers/kconfig_controller.go
+++ b/controllers/kconfig_controller.go
@@ -358,6 +358,14 @@ func (r *KconfigReconciler) updateKconfigBinding(ctx context.Context, kc *kconfi
 					Name:        kc.Name,
 					Labels:      kc.Labels,
 					Annotations: kc.Annotations,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       kc.Kind,
+							APIVersion: kc.APIVersion,
+							Name:       kc.Name,
+							UID:        kc.UID,
+						},
+					},
 				},
 				Spec: kconfigcontrollerv1beta1.KconfigBindingSpec{
 					Level:    0,

--- a/controllers/kconfigbinding_controller.go
+++ b/controllers/kconfigbinding_controller.go
@@ -135,7 +135,7 @@ func (r *KconfigBindingReconciler) updateStatefulSets(ctx context.Context, kcb k
 			statefulSetCopy.Spec.Template.Annotations = make(map[string]string)
 		}
 		generationAnnotation := fmt.Sprintf("%s%s", GenerationAnnotationPrefix, kcb.Name)
-		statefulSetCopy.Spec.Template.Annotations[generationAnnotation] = string(kcb.Generation)
+		statefulSetCopy.Spec.Template.Annotations[generationAnnotation] = fmt.Sprint(kcb.Generation)
 		if err := r.Update(ctx, statefulSetCopy); err != nil {
 			return fmt.Errorf("error updating statefulSet: %s", err.Error())
 		}


### PR DESCRIPTION
The owner will be the corresponding Kconfig object. This will allow for garbage collecting of Kconfigbinding when the corresponding Kconfig is deleted.