### PR TITLE
Annotation on kconfig to disable template refresh

### DIFF
--- a/controllers/const.go
+++ b/controllers/const.go
@@ -12,4 +12,6 @@ const (
 
 	AllowTemplateUpdatesAnnotation = "kconfigcontroller.atteg.com/refresh-template"
 	GenerationAnnotationPrefix     = "kconfigcontroller.atteg.com/"
+
+	KconfigDisableTemplateRefresh = "kconfigcontroller.atteg.com/disable-template-refresh"
 )

--- a/controllers/kconfig_controller.go
+++ b/controllers/kconfig_controller.go
@@ -379,6 +379,8 @@ func (r *KconfigReconciler) updateKconfigBinding(ctx context.Context, kc *kconfi
 		}
 	}
 
+	kcb.Annotations = kc.Annotations
+	kcb.Labels = kc.Labels
 	kcb.Spec.Level = kc.Spec.Level
 	kcb.Spec.Envs = envVars
 	kcb.Spec.Selector = kc.Spec.Selector

--- a/controllers/kconfigbinding_controller.go
+++ b/controllers/kconfigbinding_controller.go
@@ -53,7 +53,11 @@ func (r *KconfigBindingReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if kcb.Status.ObservedGeneration != kcb.Generation {
+	disableTemplateRefresh := "false"
+	if val, ok := kcb.Annotations[KconfigDisableTemplateRefresh]; ok {
+		disableTemplateRefresh = val
+	}
+	if kcb.Status.ObservedGeneration != kcb.Generation && disableTemplateRefresh != "true" {
 		err := r.processKconfigBinding(ctx, kcb)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("error processing kconfigBinding: %s", err.Error())

--- a/main.go
+++ b/main.go
@@ -19,18 +19,17 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/att-cloudnative-labs/kconfig-controller/webhooks"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
 	kconfigcontrollerv1beta1 "github.com/att-cloudnative-labs/kconfig-controller/api/v1beta1"
 	"github.com/att-cloudnative-labs/kconfig-controller/controllers"
+	"github.com/att-cloudnative-labs/kconfig-controller/webhooks"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	// +kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
Set kconfig_controller to copy all labels and annotations to kconfigbinding and recognize annotation, kconfigcontroller.atteg.com/disable-template-refresh, which if seen by kconfigbinding_controller (with value "true"), will not update the deployment template